### PR TITLE
Dockerfile: Fix ubuntu version to 16.04.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:16.04
 
 #updated by b_rad <brae/dot/04/plus/tizonia/at/gmail/dot/com>
 LABEL maintainer "Juan A. Rubio <juan.rubio@aratelia.com>"


### PR DESCRIPTION
Then main reason to bump this is simply because the current version hosted on dockerhub has an outdated version of the python youtube-dl module which causes errors. This would be fixed with a quick rebuild of the dockerfile.

Error from youtube-dl:

```
# docker-tizonia --youtube-audio-mix-search "Queen Official"
tizonia 0.14.0. Copyright (C) 2018 Juan A. Rubio
This software is part of the Tizonia project <http://tizonia.org>

ERROR: Signature extraction failed: Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/youtube_dl/extractor/youtube.py", line 1191, in _decrypt_signature
    video_id, player_url, s
  File "/usr/local/lib/python2.7/dist-packages/youtube_dl/extractor/youtube.py", line 1102, in _extract_signature_function
    res = self._parse_sig_js(code)
  File "/usr/local/lib/python2.7/dist-packages/youtube_dl/extractor/youtube.py", line 1163, in _parse_sig_js
    jscode, 'Initial JS player signature function name', group='sig')
  File "/usr/local/lib/python2.7/dist-packages/youtube_dl/extractor/common.py", line 808, in _search_regex
    raise RegexNotFoundError('Unable to extract %s' % _name)
RegexNotFoundError: Unable to extract Initial JS player signature function name; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
 (caused by RegexNotFoundError(u'Unable to extract \x1b[0;34mInitial JS player signature function name\x1b[0m; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.',)); please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
[YouTube] (IOError) : ERROR: Signature extraction failed: Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/youtube_dl/extractor/youtube.py", line 1191, in _decrypt_signature
    video_id, player_url, s
  File "/usr/local/lib/python2.7/dist-packages/youtube_dl/extractor/youtube.py", line 1102, in _extract_signature_function
    res = self._parse_sig_js(code)
  File "/usr/local/lib/python2.7/dist-packages/youtube_dl/extractor/youtube.py", line 1163, in _parse_sig_js
    jscode, 'Initial JS player signature function name', group='sig')
  File "/usr/local/lib/python2.7/dist-packages/youtube_dl/extractor/common.py", line 808, in _search_regex
    raise RegexNotFoundError('Unable to extract %s' % _name)
RegexNotFoundError: Unable to extract Initial JS player signature function name; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
 (caused by RegexNotFoundError(u'Unable to extract \x1b[0;34mInitial JS player signature function name\x1b[0m; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.',)); please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.

tizonia exiting (OMX_ErrorInsufficientResources).

 [OMX.Aratelia.audio_source.http:port:0]
 [OMX_ErrorInsufficientResources]
```