### PR TITLE
MacOS working docker-tizonia

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,24 @@
 Containerized [**Tizonia**](http://www.tizonia.org/) cloud music player that uses the host's sound system.
 
 ## Mac Support
-Too allow for usage on Mac, it is required that pulse audio to be installed via homebrew, and the following lines in /usr/local/Cellar/pulseaudio/13.0/etc/pulse/default.pa to be uncommented:
+# Step 1) 
+
+It is required that pulse audio to be installed via homebrew, and the following lines in /usr/local/Cellar/pulseaudio/13.0/etc/pulse/default.pa to be uncommented:
 
 load-module module-esound-protocol-tcp
 load-module module-native-protocol-tcp
 
+# Step 2) 
+
 Too adjust the device being used for output, bring up a list of possible output devices and select one as the default sink:
+
 pactl list short sinks
 
 pacmd set-default-sink n (Where N is the chosen output number)
 
-Next, start the Pulseaudio daemon:
+# Step 3) 
+
+Start the Pulseaudio daemon:
 
 pulseaudio --load=module-native-protocol-tcp --exit-idle-time=-1 --daemon
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 Containerized [**Tizonia**](http://www.tizonia.org/) cloud music player that uses the host's sound system.
 
 ## Mac Support
-# Step 1) 
+## Step 1) 
 
 It is required that pulse audio to be installed via homebrew, and the following lines in /usr/local/Cellar/pulseaudio/13.0/etc/pulse/default.pa to be uncommented:
 
 load-module module-esound-protocol-tcp
 load-module module-native-protocol-tcp
 
-# Step 2) 
+## Step 2) 
 
 Too adjust the device being used for output, bring up a list of possible output devices and select one as the default sink:
 
@@ -20,7 +20,7 @@ pactl list short sinks
 
 pacmd set-default-sink n (Where N is the chosen output number)
 
-# Step 3) 
+## Step 3) 
 
 Start the Pulseaudio daemon:
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ docker-tizonia --youtube-audio-mix-search "Queen Official"
 
 ### Step 1)
 
-It is required that pulse audio to be installed via homebrew
+It is required that PulseAudio to be installed via `homebrew`
 (`brew install pulseaudio`), and the following lines in
 `/usr/local/Cellar/pulseaudio/13.0/etc/pulse/default.pa` to be uncommented:
 
@@ -54,7 +54,7 @@ load-module module-native-protocol-tcp
 
 ### Step 2)
 
-Too adjust the device being used for output, bring up a list of possible output devices and
+To choose the device being used for output, bring up a list of possible output devices and
 select one as the default sink:
 
 ```bash
@@ -71,8 +71,8 @@ Start the Pulseaudio daemon:
 pulseaudio --load=module-native-protocol-tcp --exit-idle-time=-1 --daemon
 ```
 
-You should now be able to utilize the docker container to route audio from the docker container
-to the host machine!
+You should now be able to utilize the `docker-tizonia` script to route audio from the docker
+container to the host machine!
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,19 @@ Containerized [**Tizonia**](http://www.tizonia.org/) cloud music player that use
 
 ## Mac Support
 Too allow for usage on Mac, it is required that pulse audio to be installed via homebrew, and the following lines in /usr/local/Cellar/pulseaudio/13.0/etc/pulse/default.pa to be uncommented:
+
 load-module module-esound-protocol-tcp
 load-module module-native-protocol-tcp
+
 Too adjust the device being used for output, bring up a list of possible output devices and select one as the default sink:
 pactl list short sinks
+
 pacmd set-default-sink n (Where N is the chosen output number)
+
 Next, start the Pulseaudio daemon:
+
 pulseaudio --load=module-native-protocol-tcp --exit-idle-time=-1 --daemon
+
 You should now be able to utilize the docker container to route audio from the docker-image to the client device!
 
 ## Audio Output

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 
 Containerized [**Tizonia**](http://www.tizonia.org/) cloud music player that uses the host's sound system.
 
+## Mac Support
+Too allow for usage on Mac, it is required that pulse audio to be installed via homebrew, and the following lines in /usr/local/Cellar/pulseaudio/13.0/etc/pulse/default.pa to be uncommented:
+load-module module-esound-protocol-tcp
+load-module module-native-protocol-tcp
+Too adjust the device being used for output, bring up a list of possible output devices and select one as the default sink:
+pactl list short sinks
+pacmd set-default-sink n (Where N is the chosen output number)
+Next, start the Pulseaudio daemon:
+pulseaudio --load=module-native-protocol-tcp --exit-idle-time=-1 --daemon
+You should now be able to utilize the docker container to route audio from the docker-image to the client device!
+
 ## Audio Output
 
 Tizonia connects as a client directly to the hosts PulseAudio server and uses

--- a/README.md
+++ b/README.md
@@ -4,30 +4,6 @@
 
 Containerized [**Tizonia**](http://www.tizonia.org/) cloud music player that uses the host's sound system.
 
-## Mac Support
-## Step 1) 
-
-It is required that pulse audio to be installed via homebrew, and the following lines in /usr/local/Cellar/pulseaudio/13.0/etc/pulse/default.pa to be uncommented:
-
-load-module module-esound-protocol-tcp
-load-module module-native-protocol-tcp
-
-## Step 2) 
-
-Too adjust the device being used for output, bring up a list of possible output devices and select one as the default sink:
-
-pactl list short sinks
-
-pacmd set-default-sink n (Where N is the chosen output number)
-
-## Step 3) 
-
-Start the Pulseaudio daemon:
-
-pulseaudio --load=module-native-protocol-tcp --exit-idle-time=-1 --daemon
-
-You should now be able to utilize the docker container to route audio from the docker-image to the client device!
-
 ## Audio Output
 
 Tizonia connects as a client directly to the hosts PulseAudio server and uses
@@ -39,23 +15,7 @@ its use.
 
 ## Launch Command
 
-Use the convenience script [docker-tizonia](docker-tizonia):
-
-``` bash
-#!/bin/bash
-
-USER_ID=$(id -u);
-GROUP_ID=$(id -g);
-
-docker run -it --rm \
-    -e PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native \
-    --volume=${XDG_RUNTIME_DIR}/pulse:${XDG_RUNTIME_DIR}/pulse \
-    --volume="${HOME}/.config/tizonia":/home/tizonia/.config/tizonia \
-    --volume "${HOME}/.config/pulse/cookie":/home/tizonia/.config/pulse/cookie \
-    --name tizonia \
-    tizonia/docker-tizonia "$@";
-
-```
+Use the convenience script [docker-tizonia](docker-tizonia).
 
 The script bind mounts the host's '$HOME/.config/tizonia' to make
 'tizonia.conf' available inside the container.
@@ -78,6 +38,41 @@ $ sudo install docker-tizonia /usr/local/bin
 $ docker-tizonia --youtube-audio-mix-search "Queen Official"
 
 ```
+
+## Mac Support
+
+### Step 1)
+
+It is required that pulse audio to be installed via homebrew
+(`brew install pulseaudio`), and the following lines in
+`/usr/local/Cellar/pulseaudio/13.0/etc/pulse/default.pa` to be uncommented:
+
+```
+load-module module-esound-protocol-tcp
+load-module module-native-protocol-tcp
+```
+
+### Step 2)
+
+Too adjust the device being used for output, bring up a list of possible output devices and
+select one as the default sink:
+
+```bash
+pactl list short sinks
+
+pacmd set-default-sink n  # where n is the chosen output number
+```
+
+### Step 3)
+
+Start the Pulseaudio daemon:
+
+```bash
+pulseaudio --load=module-native-protocol-tcp --exit-idle-time=-1 --daemon
+```
+
+You should now be able to utilize the docker container to route audio from the docker container
+to the host machine!
 
 # License
 

--- a/docker-tizonia
+++ b/docker-tizonia
@@ -3,9 +3,18 @@
 USER_ID=$(id -u);
 GROUP_ID=$(id -g);
 
-docker run --rm -v $HOME:$HOME -w $HOME -it\
-	-e PULSE_SERVER=docker.for.mac.localhost\
+if uname -s | grep -iq "Darwin" ; then
+  pulse_server=docker.for.mac.localhost
+  runtime_dir="$HOME"
+else
+  pulse_server=unix:"${XDG_RUNTIME_DIR}/pulse/native"
+  runtime_dir="${XDG_RUNTIME_DIR}/pulse"
+fi
+
+docker run -it --rm \
+    -e PULSE_SERVER="$pulse_server" \
+    --volume="$runtime_dir":"$runtime_dir" \
     --volume="${HOME}/.config/tizonia":/home/tizonia/.config/tizonia \
-    --volume "${HOME}/.config/pulse/cookie":/home/tizonia/.config/pulse/cookie \
+    --volume="${HOME}/.config/pulse/cookie":/home/tizonia/.config/pulse/cookie \
     --name tizonia \
     tizonia/docker-tizonia "$@";

--- a/docker-tizonia
+++ b/docker-tizonia
@@ -3,11 +3,9 @@
 USER_ID=$(id -u);
 GROUP_ID=$(id -g);
 
-docker run -it --rm \
-    -e PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native \
-    --volume=${XDG_RUNTIME_DIR}/pulse:${XDG_RUNTIME_DIR}/pulse \
+docker run --rm -v $HOME:$HOME -w $HOME -it\
+	-e PULSE_SERVER=docker.for.mac.localhost\
     --volume="${HOME}/.config/tizonia":/home/tizonia/.config/tizonia \
     --volume "${HOME}/.config/pulse/cookie":/home/tizonia/.config/pulse/cookie \
     --name tizonia \
     tizonia/docker-tizonia "$@";
-


### PR DESCRIPTION
Requires pulse audio to be installed via homebrew, and the following lines in /usr/local/Cellar/pulseaudio/13.0/etc/pulse/default.pa to be uncommented:
load-module module-esound-protocol-tcp
load-module module-native-protocol-tcp

Might've missed a step, but from my recollection my docker-tizonia file in-conjunction with these steps should allow MacOSX support, works on my device :) 