### PR TITLE
Add volume to bind cache directory for debug output

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ docker run -it --rm \
     --volume=${XDG_RUNTIME_DIR}/pulse:${XDG_RUNTIME_DIR}/pulse \
     --volume="${HOME}/.config/tizonia":/home/tizonia/.config/tizonia \
     --volume "${HOME}/.config/pulse/cookie":/home/tizonia/.config/pulse/cookie \
+    --volume="${HOME}/.cache":/home/tizonia/.cache \
     --name tizonia \
     tizonia/docker-tizonia "$@";
 
@@ -38,6 +39,10 @@ The script bind mounts the host's '$HOME/.config/tizonia' to make
 
 > NOTE: The Tizonia process running inside the container needs 'rwx'
 > permissions on this directory.
+
+The script also bind mounts the host's '$HOME/.cache' to allow debug logs to be
+written to disk. For example, gmusicapi logs for Google Play Music can be found
+at '$HOME/.cache/gmusicapi/log/gmusicapi.log'
 
 Once the script is in your path, and the permissions of '$HOME/.config/tizonia'
 have been changed, just use the usual Tizonia commands:

--- a/docker-tizonia
+++ b/docker-tizonia
@@ -8,6 +8,7 @@ docker run -it --rm \
     --volume=${XDG_RUNTIME_DIR}/pulse:${XDG_RUNTIME_DIR}/pulse \
     --volume="${HOME}/.config/tizonia":/home/tizonia/.config/tizonia \
     --volume "${HOME}/.config/pulse/cookie":/home/tizonia/.config/pulse/cookie \
+    --volume="${HOME}/.cache":/home/tizonia/.cache \
     --name tizonia \
     tizonia/docker-tizonia "$@";
 


### PR DESCRIPTION
 - Previously, because the configured debug log for gmusicapi didn't exist, it was sending all debug log to console with the normal Tizonia output
 - To fix that (sending debug logs to disk and not to console output), bind host machine .cache directory

Fixes https://github.com/tizonia/docker-tizonia/issues/10